### PR TITLE
Avoid static classes

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -2,9 +2,10 @@ include: package:pedantic/analysis_options.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
-# linter:
-#   rules:
-#     - camel_case_types
+linter:
+  rules:
+    - camel_case_types
+    - avoid_classes_with_only_static_members
 
 analyzer:
   exclude:


### PR DESCRIPTION
Reasoning:
* [Effective Dart](https://dart.dev/guides/language/effective-dart/design#avoid-defining-a-class-that-contains-only-static-members)
* [Lint Rule](https://dart-lang.github.io/linter/lints/avoid_classes_with_only_static_members.html)
