### PR TITLE
Suggested rules

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -1,11 +1,13 @@
 include: package:pedantic/analysis_options.1.8.0.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
-# Uncomment to specify additional rules.
+
 linter:
   rules:
+    # additional rules not included in pedantic 1.8.0
     - always_declare_return_types
     - always_put_required_named_parameters_first
+    - avoid_classes_with_only_static_members
     - camel_case_types
     - directives_ordering
     - empty_statements
@@ -14,7 +16,7 @@ linter:
     - implementation_imports
     - non_constant_identifier_names
     - package_names
-    - prefer_double_quotes
+    - prefer_single_quotes
     - prefer_final_locals
     - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters
@@ -33,35 +35,52 @@ analyzer:
     implicit-dynamic: false
 
   errors:
-    avoid_empty_else: false   #not needed with empty_statements rule above
-    avoid_shadowing_type_parameters: false
+    # ignore rules from pedantic default list
+    avoid_empty_else: false # unnecessary since empty_statements rule is in place
     null_closures: false
     use_rethrow_when_possible: false
     slash_for_doc_comments: false 
     prefer_iterable_whereType: false
     unnecessary_null_in_if_null_operators: false
     
+    # default pedantic rules set to errors
+    avoid_init_to_null: error
+    avoid_relative_lib_imports: error
+    avoid_return_types_on_setters: error
+    avoid_shadowing_type_parameters: error
+    avoid_types_as_parameter_names: error
+    curly_braces_in_flow_control_structures: error
+    empty_catches: error
+    empty_constructor_bodies: error
+    library_names: error
+    library_prefixes: error
+    no_duplicate_case_values: error
+    prefer_contains: error
+    prefer_equal_for_default_values: error
+    prefer_is_empty: error
+    prefer_is_not_empty: error
+    recursive_getters: error
+    type_init_formals: error
+    unawaited_futures: error
+    unnecessary_const: error
+    unnecessary_new: error
+    unrelated_type_equality_checks: error
+    valid_regexps: error
+
+    # additional rules set to error
     always_declare_return_types: error
     always_put_required_named_parameters_first: error
-    constant_identifier_names: error  #need to decide as a team
+    avoid_classes_with_only_static_members: error
+    camel_case_types: error
+    constant_identifier_names: error
+    directives_ordering: error
     empty_statements: error
     file_names: error
-    library_names: error
-    recursive_getters: error
-    unawaited_futures: error
+    lines_longer_than_80_chars: error
+    prefer_single_quotes: error  
+    prefer_final_locals: error 
+    unnecessary_brace_in_string_interps: error
+    unnecessary_getters_setters: error
+    unnecessary_parenthesis: error
+    unnecessary_this: error
     unused_import: error
-
-    camel_case_types: warning
-    curly_braces_in_flow_control_structures: warning
-    directives_ordering: warning
-    library_prefixes: warning
-    lines_longer_than_80_chars: warning
-    prefer_contains: warning
-    prefer_double_quotes: warning   #need to decide as a team
-    prefer_final_locals: warning    #need to decide as a team
-    prefer_equal_for_default_values: warning  #need to decide as a team
-    unnecessary_brace_in_string_interps: warning
-    unnecessary_getters_setters: warning
-    unnecessary_parenthesis: warning
-    unnecessary_new: warning
-    unnecessary_this: warning

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -2,15 +2,66 @@ include: package:pedantic/analysis_options.1.8.0.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
-# linter:
-#   rules:
-#     - camel_case_types
+linter:
+  rules:
+    - always_declare_return_types
+    - always_put_required_named_parameters_first
+    - camel_case_types
+    - directives_ordering
+    - empty_statements
+    - file_names
+    - lines_longer_than_80_chars
+    - implementation_imports
+    - non_constant_identifier_names
+    - package_names
+    - prefer_double_quotes
+    - prefer_final_locals
+    - unnecessary_brace_in_string_interps
+    - unnecessary_getters_setters
+    - unnecessary_parenthesis
+    - unnecessary_this
+    - unused_import
 
 analyzer:
   exclude:
     - lib/**.g.dart
     - test_driver/**
     - test/**
+
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+
+  errors:
+    avoid_empty_else: false   #not needed with empty_statements rule above
+    avoid_shadowing_type_parameters: false
+    null_closures: false
+    use_rethrow_when_possible: false
+    slash_for_doc_comments: false 
+    prefer_iterable_whereType: false
+    unnecessary_null_in_if_null_operators: false
+    
+    always_declare_return_types: error
+    always_put_required_named_parameters_first: error
+    constant_identifier_names: error  #need to decide as a team
+    empty_statements: error
+    file_names: error
+    library_names: error
+    recursive_getters: error
+    unawaited_futures: error
+    unused_import: error
+
+    camel_case_types: warning
+    curly_braces_in_flow_control_structures: warning
+    directives_ordering: warning
+    library_prefixes: warning
+    lines_longer_than_80_chars: warning
+    prefer_contains: warning
+    prefer_double_quotes: warning   #need to decide as a team
+    prefer_final_locals: warning    #need to decide as a team
+    prefer_equal_for_default_values: warning  #need to decide as a team
+    unnecessary_brace_in_string_interps: warning
+    unnecessary_getters_setters: warning
+    unnecessary_parenthesis: warning
+    unnecessary_new: warning
+    unnecessary_this: warning

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
   sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
-  pedantic: ^1.8.0
+  pedantic: ^1.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
   sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
-  pedantic: ^1.7.0
+  pedantic: ^1.8.0


### PR DESCRIPTION
Initial take on default rules that we should use. Up for discussion on what the team would like to use.

- updated files to only use the 1.8.0 library; this will prevent issues when the library gets update. This is recommended when continuous builds or presubmit checks are in place.

- Changed severity levels on a handful of rules to treat as errors and others as warnings to highlight issues (over the default info). This will help with standardizing the code. In theory, rules we decide to implement should all be set to errors if not follow, but this is an item we need to discuss as a team.