### PR TITLE
Removed unsupported rule

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -24,7 +24,6 @@ linter:
     - unnecessary_new
     - unnecessary_parenthesis
     - unnecessary_this
-    - unused_import
 
 analyzer:
   exclude:
@@ -85,4 +84,3 @@ analyzer:
     unnecessary_getters_setters: error
     unnecessary_parenthesis: error
     unnecessary_this: error
-    unused_import: error


### PR DESCRIPTION
Removed "unused_imports" so bitrise will not fail on checks. Will look at adding this back in once it is supported fully.