### PR TITLE
Added 'generated' directory to be excluded

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -28,6 +28,7 @@ linter:
 analyzer:
   exclude:
     - lib/**.g.dart
+    - lib/generated/**
     - test_driver/**
     - test/**
 


### PR DESCRIPTION
This directory and files located within are autogenerated from the VSCode localization plugin and should not processed.