### PR TITLE
Exclude monorepo style packages directory

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -30,6 +30,7 @@ analyzer:
   exclude:
     - lib/**.g.dart
     - lib/generated/**
+    - packages/**
     - test_driver/**
     - test/**
 


### PR DESCRIPTION
Let's explicitely run analyze per package instead
of letting the analyzer run on an entire repository.