### PR TITLE
Remove any paths from excluded analysis

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -32,11 +32,8 @@ linter:
 
 analyzer:
   exclude:
-    - lib/**.g.dart
-    - lib/generated/**
-    - packages/**
-    - test_driver/**
-    - test/**
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
 
   strong-mode:
     implicit-casts: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: resideo_pedantic
-description: A starting point for Dart libraries or applications.
+description: Resideo's pedantic preferences
 publish_to: none
 
 environment:
-  sdk: ">=2.9.2 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   pedantic: ^1.9.0


### PR DESCRIPTION
Changes in 2.10.0 cause any analysis, including syntax errors, to be
ignored if you exclude a file in `analysis_options`. Removing this
as a forced option from `resideo_pedantic` because there isn't
a way to override this if you inherit analysis options.

If needed, add the ignored directories directly to your package/app.

```yaml

analyzer:
  exclude:
    - test_driver/**
    - test/**
    - "**/*.g.dart"
    - "**/*.freezed.dart"

```